### PR TITLE
Add support for non-standard SMTP LOGIN clients

### DIFF
--- a/MITMsmtp/auth/authLogin.py
+++ b/MITMsmtp/auth/authLogin.py
@@ -43,7 +43,7 @@ class authLogin (authMethod):
     """
     @staticmethod
     def matchMethod(authLine):
-        match = re.match("AUTH LOGIN$", authLine)
+        match = re.match("^AUTH LOGIN", authLine, re.IGNORECASE)
         if (match == None):
             return False
         else:


### PR DESCRIPTION
-Some clients do not comply with the capitalization of the SMTP AUTH messages. This allows the parser to ignore case on the client message