### PR TITLE
Compatibility with smtplib

### DIFF
--- a/MITMsmtp/SMTPHandler.py
+++ b/MITMsmtp/SMTPHandler.py
@@ -78,9 +78,9 @@ class SMTPHandler(StreamRequestHandler):
     """
     def readEHLO(self):
         line = self.readLine()
-        match = re.match("EHLO (.*)", line)
+        match = re.match("EHLO (.*)", line, re.IGNORECASE)
         if (match == None):
-            if (line == "EHLO"): #Handle empty clientname
+            if (line.upper() == "EHLO"): #Handle empty clientname
                 self.message.setClientName("")
             else:
                 raise ValueError("Invalid EHLO sent by client")

--- a/MITMsmtp/SMTPServer.py
+++ b/MITMsmtp/SMTPServer.py
@@ -46,7 +46,7 @@ class SMTPServer(TCPServer):
                  STARTTLS=False,
                  SSL=False,
                  printLines=False,
-                 ssl_version=ssl.PROTOCOL_TLSv1,
+                 ssl_version=ssl.PROTOCOL_TLS,
                  bind_and_activate=True):
         TCPServer.__init__(self, server_address, RequestHandlerClass, bind_and_activate) #TODO: move down!
         self.name = server_name


### PR DESCRIPTION
I'm trying to intercept a simple client written in python that uses encyption. Here is the code (`client.py`):
```py
import smtplib
import time

con = smtplib.SMTP_SSL('127.0.0.1', 4650)
con.ehlo()
con.login('user', 'pass')

# Prevent client from closing the connection
time.sleep(10000)
```

I started MITMsmtp like this
```sh
$ env/bin/MITMsmtp --port 4650 --SSL
```

The first error appears in the client:
```
$ python client.py
Traceback (most recent call last):
  File "/tmp/tmp.e3mZH3icta/MITMsmtp/client.py", line 4, in <module>
    con = smtplib.SMTP_SSL('127.0.0.1', 4650)
  File "/usr/lib/python3.9/smtplib.py", line 1045, in __init__
    SMTP.__init__(self, host, port, local_hostname, timeout,
  File "/usr/lib/python3.9/smtplib.py", line 255, in __init__
    (code, msg) = self.connect(host, port)
  File "/usr/lib/python3.9/smtplib.py", line 341, in connect
    self.sock = self._get_socket(host, port, self.timeout)
  File "/usr/lib/python3.9/smtplib.py", line 1052, in _get_socket
    new_socket = self.context.wrap_socket(new_socket,
  File "/usr/lib/python3.9/ssl.py", line 500, in wrap_socket
    return self.sslsocket_class._create(
  File "/usr/lib/python3.9/ssl.py", line 1040, in _create
    self.do_handshake()
  File "/usr/lib/python3.9/ssl.py", line 1309, in do_handshake
    self._sslobj.do_handshake()
ConnectionResetError: [Errno 104] Connection reset by peer
```
This is solved in the first commit - 23fe76048f842a535ee484e88bfde774efab1c1a

---

The next error appears in MITMsmtp because `smtplib` sends `ehlo [127.0.0.1]` which does not match with the EHLO expected by MITMsmtp
```
$ env/bin/MITMsmtp --port 4650 --SSL
[INFO] Using default certificates
Waiting for messages

Closed connection!
----------------------------------------
Exception occurred during processing of request from ('127.0.0.1', 55978)
Traceback (most recent call last):
  File "/usr/lib/python3.9/socketserver.py", line 683, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.9/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.9/socketserver.py", line 747, in __init__
    self.handle()
  File "/tmp/tmp.e3mZH3icta/MITMsmtp/env/lib/python3.9/site-packages/MITMsmtp-0.0.3.dev0-py3.9.egg/MITMsmtp/SMTPHandler.py", line 65, in handle
    raise e
  File "/tmp/tmp.e3mZH3icta/MITMsmtp/env/lib/python3.9/site-packages/MITMsmtp-0.0.3.dev0-py3.9.egg/MITMsmtp/SMTPHandler.py", line 50, in handle
    self.readEHLO()
  File "/tmp/tmp.e3mZH3icta/MITMsmtp/env/lib/python3.9/site-packages/MITMsmtp-0.0.3.dev0-py3.9.egg/MITMsmtp/SMTPHandler.py", line 86, in readEHLO
    raise ValueError("Invalid EHLO sent by client")
ValueError: Invalid EHLO sent by client
----------------------------------------
```
Solved in the second commit - 0a3da5774a1b78c543adbef44042d9adfea8a8de

---

With this patch, MITMsmtp catches the login credentials:
```
$ env/bin/MITMsmtp --port 4650 --SSL
[INFO] Using default certificates
Waiting for messages

=== Login ===
Username: user
Password: pass
```