### PR TITLE
Update regex to accept MAIL FROM:<Name.Surname@sub.doma.in> and RCPT …

### DIFF
--- a/MITMsmtp/SMTPHandler.py
+++ b/MITMsmtp/SMTPHandler.py
@@ -141,8 +141,8 @@ class SMTPHandler(StreamRequestHandler):
     """
     def readSender(self):
         line = self.readLine()
-        match = re.match("MAIL FROM:\<([a-zA-z0-9]*@[a-zA-z0-9\.]*)\>", line)
-        if (match == None):
+        match = re.match(r"MAIL FROM:<([a-zA-Z0-9._+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>", line)
+        if match is None:
             raise ValueError("Could not read sender")
 
         self.message.setSender(match.group(1))
@@ -162,7 +162,7 @@ class SMTPHandler(StreamRequestHandler):
             if (line == "DATA"):
                 return
 
-            match = re.match("RCPT TO:\<([a-zA-z0-9]*@[a-zA-z0-9\.]*)\>", line)
+            match = re.match(r"RCPT TO:<([a-zA-Z0-9._+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>", line)
             if (match == None):
                 raise ValueError("Could not read recipients")
             self.message.addRecipient(match.group(1))


### PR DESCRIPTION
…TO:<Name.Surname@sub.doma.in>

Fixing the following error for both FROM and RCPT:

C:MAIL FROM:<Name.Surname@sub.doma.in>
Closed connection!
----------------------------------------
Exception occurred during processing of request from ('10.134.41.222', 53760) Traceback (most recent call last):
  File "/usr/lib/python3.11/socketserver.py", line 691, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.11/socketserver.py", line 361, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.11/socketserver.py", line 755, in __init__
    self.handle()
  File "/usr/local/lib/python3.11/dist-packages/MITMsmtp-0.0.3.dev0-py3.11.egg/MITMsmtp/SMTPHandler.py", line 65, in handle
    raise e
  File "/usr/local/lib/python3.11/dist-packages/MITMsmtp-0.0.3.dev0-py3.11.egg/MITMsmtp/SMTPHandler.py", line 56, in handle
    self.readSender()
  File "/usr/local/lib/python3.11/dist-packages/MITMsmtp-0.0.3.dev0-py3.11.egg/MITMsmtp/SMTPHandler.py", line 146, in readSender
    raise ValueError("Could not read sender")
ValueError: Could not read sender
----------------------------------------